### PR TITLE
Fix `objax` variable `None`-check

### DIFF
--- a/jeffnet/objax/layers/linear.py
+++ b/jeffnet/objax/layers/linear.py
@@ -71,7 +71,7 @@ class Conv2d(Module):
             x, self.weight.value, self.strides, self.padding,
             rhs_dilation=self.dilations, feature_group_count=self.groups,
             dimension_numbers=('NCHW', 'OIHW', 'NCHW'))
-        if self.bias:
+        if self.bias is not None:
             y += self.bias.value.reshape((1, -1, 1, 1))
         return y
 
@@ -102,6 +102,6 @@ class Linear(Module):
     def __call__(self, x: JaxArray) -> JaxArray:
         """Returns the results of applying the linear transformation to input x."""
         y = jnp.dot(x, self.weight.value.transpose())
-        if self.bias:
+        if self.bias is not None:
             y += self.bias.value
         return y


### PR DESCRIPTION
## Description

Hi @rwightman, I was playing around with `jeffnet` for a bit, and I found one issue with `objax` 1.6.0 raising a `TypeError` when checking whether an `objax.variable` is `None` as `if self.var`, as it needs to be checked as `if self.var is not None` or `if self.var is None`, depending on the desired behavior.

Thanks for your great work always and happy holidays! 🤗

## How to reproduce the issue

```python
from jeffnet.objax import create_model
from jax import numpy as jnp

model = create_model("pt_efficientnet_lite0", pretrained=True)

y = model(jnp.ones((1, 3, 224, 224)), training=False)
```

## Dependency versions

* `jax` version 0.3.25
* `jaxlib` version 0.3.25
* `objax` version 1.6.0
* `jeffnet` version latest from `master` branch at https://github.com/rwightman/efficientnet-jax/tree/a65811fbf63cb90b9ad0724792040ce93b749303